### PR TITLE
Always switch logouhr on when space is opened

### DIFF
--- a/conf/rules/logouhr.rules
+++ b/conf/rules/logouhr.rules
@@ -15,6 +15,8 @@ then
 		logInfo("Logouhr", "Schalte Logouhr auf hinterlegten Farbwert")
 		sendCommand( Logouhr_ON, ON)
 	]
+	// Logouhr einschalten
+        Logouhr_ON.sendCommand(ON)
 end
 
 rule "N39 closed"


### PR DESCRIPTION
Change the default behaviour to "always on when somebody is there".
Normally we want to see this device, so it may as well be activated.
Deactivation can be achieved via OpenHAB control panel or some other
means (like a script on Konfuzius).

Makes us more independent from the double-tap on a sonoff device.