### PR TITLE
Shuttercontrol lobby light

### DIFF
--- a/conf/items/lobby.items
+++ b/conf/items/lobby.items
@@ -16,3 +16,5 @@ Switch Stereo_Hauptschalter "Stereo - Hauptschalter" (Media, Grp_SpaceShutdown) 
 
 Dimmer CC_Volume "Chromecast Volume" (Media, CC)
 Player CC_Music "Chromecast Music" <player> (Media, CC)
+
+String ShuttercontrolBtn "Shutter Light Button" <light> (Lobby) {mqtt="<[helium:Netz39/Things/Shuttercontrol/Button/Events:command:default]"}

--- a/conf/rules/shuttercontrol.rules
+++ b/conf/rules/shuttercontrol.rules
@@ -1,0 +1,8 @@
+rule "Shuttercontrol triggers Lobby Light"
+when
+        Item ShuttercontrolBtn received update
+then
+        // Emulate sonoff button press,
+        // so all special behaviour can go there
+        postUpdate(LobbyButton, 1)
+end


### PR DESCRIPTION
Control the lobby lights with buttons from shuttercontrol panel.

(This is a temporary solution until other switches are available and will allow to put the sonoff to a better position in the sense of electrical installation, where it cannot be reached by the user.)